### PR TITLE
Fix timing issue on start

### DIFF
--- a/.github/workflows/build-matterbridge-plugin.yml
+++ b/.github/workflows/build-matterbridge-plugin.yml
@@ -2,6 +2,10 @@ name: Build and lint
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-matterbridge-plugin.yml
+++ b/.github/workflows/build-matterbridge-plugin.yml
@@ -1,11 +1,15 @@
 name: Build and lint
 
-on: [push, pull_request]
-
+on:
+    push:
+        tags-ignore:
+            - 'v*'
+    pull_request:
+    
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-matterbridge-plugin.yml
+++ b/.github/workflows/build-matterbridge-plugin.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 23.x]
+        node-version: [20.x, 22.x, 23.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge-loxone",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-loxone",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "node-ansi-logger": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge-loxone",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Loxone Matterbridge plugin",
   "author": "Andras Gaal",
   "license": "MIT",

--- a/src/devices/PushButton.ts
+++ b/src/devices/PushButton.ts
@@ -1,0 +1,35 @@
+import { bridgedNode, powerSource, genericSwitch } from 'matterbridge';
+import { LoxonePlatform } from '../platform.js';
+import { LoxoneDevice } from './LoxoneDevice.js';
+import { LoxoneUpdateEvent } from '../data/LoxoneUpdateEvent.js';
+import { LoxoneValueUpdateEvent } from '../data/LoxoneValueUpdateEvent.js';
+
+class PushButton extends LoxoneDevice {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(structureSection: any, platform: LoxonePlatform) {
+    super(
+      structureSection,
+      platform,
+      [genericSwitch, bridgedNode, powerSource],
+      [structureSection.states.active],
+      'button',
+      `${genericSwitch.name}_${structureSection.uuidAction.replace(/-/g, '_')}`,
+    );
+
+    this.Endpoint.createDefaultGroupsClusterServer().createDefaultSwitchClusterServer();
+  }
+
+  override async handleLoxoneDeviceEvent(event: LoxoneUpdateEvent) {
+    if (!(event instanceof LoxoneValueUpdateEvent)) return;
+
+    if (event.value === 1) {
+      await this.Endpoint.triggerSwitchEvent('Single', this.Endpoint.log);
+    }
+  }
+
+  override async populateInitialState() {
+    this.Endpoint.log.info(`PushButton ${this.longname} does not have an initial state to populate.`);
+  }
+}
+
+export { PushButton };

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -22,6 +22,7 @@ import { OnOffButton } from './devices/OnOffButton.js';
 import { PressureSensor } from './devices/PressureSensor.js';
 import { GIT_BRANCH, GIT_COMMIT } from './gitInfo.js';
 import { AirConditioner } from './devices/AirConditioner.js';
+import { PushButton } from './devices/PushButton.js';
 
 export class LoxonePlatform extends MatterbridgeDynamicPlatform {
   public debugEnabled: boolean;
@@ -125,6 +126,15 @@ export class LoxonePlatform extends MatterbridgeDynamicPlatform {
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 
+    if (this.loxoneUUIDsAndTypes.length !== 0) {
+      while (this.initialUpdateEvents.length === 0) {
+        this.log.info('Waiting for initial update events to arrive from Loxone...');
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    this.log.info('Creating devices...');
+
     for (const uuidAndType of this.loxoneUUIDsAndTypes) {
       const uuid = uuidAndType.split(',')[0];
       const type = uuidAndType.split(',')[1];
@@ -145,8 +155,12 @@ export class LoxonePlatform extends MatterbridgeDynamicPlatform {
           device = new OnOffSwitch(structureSection, this);
           break;
         case 'button':
-          this.log.info(`Creating switch device for Loxone control with UUID ${uuid}: ${structureSection.name}`);
+          this.log.info(`Creating button device for Loxone control with UUID ${uuid}: ${structureSection.name}`);
           device = new OnOffButton(structureSection, this);
+          break;
+        case 'pushbutton':
+          this.log.info(`Creating push button for Loxone control with UUID ${uuid}: ${structureSection.name}`);
+          device = new PushButton(structureSection, this);
           break;
         case 'outlet':
           this.log.info(`Creating outlet device for Loxone control with UUID ${uuid}: ${structureSection.name}`);


### PR DESCRIPTION
In some cases initial update events didn't arrive on start, causing the plugin to fail loading. Added logic to wait for these events to arrive.